### PR TITLE
Fix off-by-one issue in render_fallback

### DIFF
--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -382,7 +382,11 @@ function M:render_fallback(state)
     self:debug("render_fallback", win)
     local border = setmetatable({ opts = vim.api.nvim_win_get_config(win) }, { __index = Snacks.win }):border_size()
     local pos = vim.api.nvim_win_get_position(win)
-    terminal.set_cursor({ pos[1] + 1 + border.top, pos[2] + border.left })
+    if ( vim.o.showtabline == 2 ) or ( vim.o.showtabline == 1 and vim.fn.tabpagenr('$') > 1 ) then
+      terminal.set_cursor({ pos[1] + border.top, pos[2] + border.left })
+    else
+      terminal.set_cursor({ pos[1] + 1 + border.top, pos[2] + border.left })
+    end
     terminal.request({
       a = "p",
       i = self.img.id,


### PR DESCRIPTION
Fix off-by-one issue in render_fallback when a tabline is shown (e.g. with plugins like bufferline.nvim).
